### PR TITLE
Get file path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 db.sqlite3
 .env
 
+# added at runtime by bentoV2
+chord_drs/startup.sh
+
 # testing related
 .coverage*
 .tox
@@ -19,3 +22,4 @@ htmlcov/
 *.pyc
 env
 __pycache__
+data/

--- a/chord_drs/routes.py
+++ b/chord_drs/routes.py
@@ -175,10 +175,13 @@ def object_info(object_id: str):
         f"[{SERVICE_NAME}] object_info X-CHORD-Internal: {request.headers.get('X-CHORD-Internal', 'not set')}"
     )
 
+    # The requester can specify object internal path to be added to the response
+    use_internal_path = bool(request.args.get("internal_path"))
+
     if drs_bundle:
-        response = build_bundle_json(drs_bundle, inside_container=inside_container)
+        response = build_bundle_json(drs_bundle, inside_container=(inside_container or use_internal_path))
     else:
-        response = build_object_json(drs_object, inside_container=inside_container)
+        response = build_object_json(drs_object, inside_container=(inside_container or use_internal_path))
 
     return jsonify(response)
 

--- a/chord_drs/routes.py
+++ b/chord_drs/routes.py
@@ -30,6 +30,10 @@ CHUNK_SIZE = 1024 * 16  # Read 16 KB at a time
 drs_service = Blueprint("drs_service", __name__)
 
 
+def strtobool(val: str):
+    return val.lower() in ("yes", "true", "t", "1", "on")
+
+
 def get_drs_base_path():
     base_path = request.host
 
@@ -176,7 +180,7 @@ def object_info(object_id: str):
     )
 
     # The requester can specify object internal path to be added to the response
-    use_internal_path = bool(request.args.get("internal_path"))
+    use_internal_path = strtobool(request.args.get("internal_path", ""))
 
     if drs_bundle:
         response = build_bundle_json(drs_bundle, inside_container=(inside_container or use_internal_path))
@@ -191,7 +195,7 @@ def object_search():
     response = []
     name = request.args.get("name")
     fuzzy_name = request.args.get("fuzzy_name")
-    internal_path = request.args.get("internal_path")
+    internal_path = request.args.get("internal_path", "")
 
     if name:
         objects = DrsObject.query.filter_by(name=name).all()
@@ -201,7 +205,7 @@ def object_search():
         return flask_errors.flask_bad_request_error("Missing GET search terms (either name or fuzzy_name)")
 
     for obj in objects:
-        response.append(build_object_json(obj, bool(internal_path)))
+        response.append(build_object_json(obj, strtobool(internal_path)))
 
     return jsonify(response)
 

--- a/chord_drs/routes.py
+++ b/chord_drs/routes.py
@@ -188,6 +188,7 @@ def object_search():
     response = []
     name = request.args.get("name")
     fuzzy_name = request.args.get("fuzzy_name")
+    internal_path = request.args.get("internal_path")
 
     if name:
         objects = DrsObject.query.filter_by(name=name).all()
@@ -197,7 +198,7 @@ def object_search():
         return flask_errors.flask_bad_request_error("Missing GET search terms (either name or fuzzy_name)")
 
     for obj in objects:
-        response.append(build_object_json(obj))
+        response.append(build_object_json(obj, bool(internal_path)))
 
     return jsonify(response)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from chord_drs.backends.minio import MinioBackend
 from chord_drs.config import BASEDIR, APP_DIR
 from chord_drs.commands import create_drs_bundle
 from chord_drs.models import DrsObject
+from chord_drs.data_sources import DATA_SOURCE_LOCAL, DATA_SOURCE_MINIO
 
 
 SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
@@ -25,7 +26,7 @@ def client_minio():
     bucket_name = "test"
     application.config["MINIO_URL"] = "http://127.0.0.1:9000"
     application.config["MINIO_BUCKET"] = bucket_name
-    application.config["SERVICE_DATA_SOURCE"] = "minio"
+    application.config["SERVICE_DATA_SOURCE"] = DATA_SOURCE_MINIO
 
     with application.app_context(), mock_s3():
         s3 = boto3.resource("s3")
@@ -44,6 +45,7 @@ def client_minio():
 @pytest.fixture
 def client_local():
     application.config["SQLALCHEMY_DATABASE_URI"] = SQLALCHEMY_DATABASE_URI
+    application.config["SERVICE_DATA_SOURCE"] = DATA_SOURCE_LOCAL
 
     with application.app_context():
         g.backend = FakeBackend()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -120,6 +120,14 @@ def test_object_inside_bento(client, drs_object):
     assert len(data["access_methods"]) == 2
 
 
+def test_object_with_internal_path(client, drs_object):
+    res = client.get(f"/objects/{drs_object.id}?internal_path=1")
+    data = res.get_json()
+
+    assert res.status_code == 200
+    validate_object_fields(data, with_internal_path=True)
+
+
 def test_bundle_and_download(client, drs_bundle):
     res = client.get(f"/objects/{drs_bundle.id}")
     data = res.get_json()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -128,6 +128,14 @@ def test_object_with_internal_path(client, drs_object):
     validate_object_fields(data, with_internal_path=True)
 
 
+def test_object_with_disabled_internal_path(client, drs_object):
+    res = client.get(f"/objects/{drs_object.id}?internal_path=0")
+    data = res.get_json()
+
+    assert res.status_code == 200
+    validate_object_fields(data, with_internal_path=False)
+
+
 def test_bundle_and_download(client, drs_bundle):
     res = client.get(f"/objects/{drs_bundle.id}")
     data = res.get_json()


### PR DESCRIPTION
This PR adds a new feature to get the internal file path to a resource within the search response body.
An extra optional parameter, `internal_path` can be added to the search query string (fuzzysearch or strict search mode). In that case, a `file` type methods is added to the response with the DRS local file path.

This is intended to avoid transferring large files over http when there is an analysis workflow done (for example conversion from VCF to MAF done separately after ingestion)

This PR also fixes an issue with the test suite within the project that was not properly configuring the local test client between runs and was in fact only testing the Minio test client.

To test: ensure that the test suite works correctly. Test in the API that adding `&internal_path=1` to a search query string returns a response containing the local paths to the files (paths beginning with /drs/bento_drs/data/obj/...)
(if testing within bentoV2, you can test by modifying the env variable to point to this `get_file_path` branch, remove the bento_drs container and the bento_drs image)