### PR TITLE
Qa/v0.5

### DIFF
--- a/chord_drs/app.py
+++ b/chord_drs/app.py
@@ -46,9 +46,13 @@ with application.app_context():
 
 # # debugger section
 # Ensure 'debugpy' is installed (via requirements.txt or manually)
-if os.environ.get('FLASK_DEBUG', False):
-    import debugpy
-    DEBUGGER_PORT = int(os.environ.get('DEBUGGER_PORT', 5678))
-    debugpy.listen(("0.0.0.0", DEBUGGER_PORT))
-    print('Attached')
+DEBUG = os.environ.get('FLASK_DEBUG', False)
+if DEBUG:
+    try:
+        import debugpy
+        DEBUGGER_PORT = int(os.environ.get('DEBUGGER_PORT', 5678))
+        debugpy.listen(("0.0.0.0", DEBUGGER_PORT))
+        print('Debugger Attached')
+    except ImportError as e:
+        print("Module debugpy not found. Run pip install debugpy to enable VSCode debugging")
 # # end debugger section

--- a/chord_drs/app.py
+++ b/chord_drs/app.py
@@ -52,7 +52,7 @@ if DEBUG:
         import debugpy
         DEBUGGER_PORT = int(os.environ.get('DEBUGGER_PORT', 5678))
         debugpy.listen(("0.0.0.0", DEBUGGER_PORT))
-        print('Debugger Attached')
-    except ImportError as e:
-        print("Module debugpy not found. Run pip install debugpy to enable VSCode debugging")
+        print('\nDebugger Attached\n')
+    except ImportError:
+        print("\nWARNING Module debugpy not found. To enable VSCode debugging, run:\n\tpip install debugpy\n")
 # # end debugger section

--- a/chord_drs/package.cfg
+++ b/chord_drs/package.cfg
@@ -1,5 +1,5 @@
 [package]
 name = chord_drs
-version = 0.5.2
+version = 0.5.3
 authors = Simon Chénard, David Lougheed
 author_emails = simon.chenard2@mcgill.ca, david.lougheed@mail.mcgill.ca


### PR DESCRIPTION
Fix issue with running debugpy in production mode. 

To test:
- try the docker instantiation in dev mode and in production mode.
- make sure that you clean your docker containers between trials
```
make stop-drs
make clean-drs
make run-drs
```

```
make stop-drs
make clean-drs
make run-drs-dev
```
(in that case check that the message "Debugger Attached" is printed in stdout)