### PR TITLE
fix: db and data dirs creation in container

### DIFF
--- a/chord_drs/package.cfg
+++ b/chord_drs/package.cfg
@@ -1,5 +1,5 @@
 [package]
 name = chord_drs
-version = 0.10.3
+version = 0.10.4
 authors = Simon Chénard, David Lougheed
 author_emails = simon.chenard2@mcgill.ca, david.lougheed@mail.mcgill.ca

--- a/entrypoint.bash
+++ b/entrypoint.bash
@@ -14,15 +14,20 @@ fi
 
 # Use the database and object folder path variables more directly to create them
 # and set their permissions.
+echo "${DATABASE}"
 if [[ -z "${DATABASE}" ]]; then
   # DATABASE is a folder; confusing naming
   mkdir -p "${DATABASE}"
   chown -R bento_user:bento_user "${DATABASE}"
+  echo "db dir created"
 fi
+
+echo "${DATA}"
 if [[ -z "${DATA}" ]]; then
   # DATA is another folder; confusing naming
   mkdir -p "${DATA}"
   chown -R bento_user:bento_user "${DATA}"
+  echo "data dir created"
 fi
 
 # Set .gitconfig for development, since we're overriding the base image entrypoint

--- a/entrypoint.bash
+++ b/entrypoint.bash
@@ -7,27 +7,23 @@ source /create_service_user.bash
 
 # Fix permissions on /drs; fix data directory permissions more specifically if needed
 chown -R bento_user:bento_user /drs
-if [[ -z "${BENTO_DRS_CONTAINER_DATA_VOLUME_DIR}" ]]; then
+if [[ -n "${BENTO_DRS_CONTAINER_DATA_VOLUME_DIR}" ]]; then
   # Location of volume mount - run chown here.
   chown -R bento_user:bento_user "${BENTO_DRS_CONTAINER_DATA_VOLUME_DIR}"
 fi
 
 # Use the database and object folder path variables more directly to create them
 # and set their permissions.
-echo "${DATABASE}"
-if [[ -z "${DATABASE}" ]]; then
+if [[ -n "${DATABASE}" ]]; then
   # DATABASE is a folder; confusing naming
   mkdir -p "${DATABASE}"
   chown -R bento_user:bento_user "${DATABASE}"
-  echo "db dir created"
 fi
 
-echo "${DATA}"
-if [[ -z "${DATA}" ]]; then
+if [[ -n "${DATA}" ]]; then
   # DATA is another folder; confusing naming
   mkdir -p "${DATA}"
   chown -R bento_user:bento_user "${DATA}"
-  echo "data dir created"
 fi
 
 # Set .gitconfig for development, since we're overriding the base image entrypoint


### PR DESCRIPTION
The directories for environment variables `BENTO_DRS_CONTAINER_DATA_VOLUME_DIR`, `DATABASE` and `DATA` were not created in `entrypoint.bash` due to faulty env var condition checks.