### PR TITLE
fix(s3): drs blob location handling

### DIFF
--- a/chord_drs/backends/s3.py
+++ b/chord_drs/backends/s3.py
@@ -113,7 +113,7 @@ class S3Backend(Backend):
     def _location_to_object_key(self, location: str) -> str:
         if location.startswith(f"s3://{self.bucket_name}"):
             # Regular S3 object path
-            return location.split(f"s3://{self.bucket_name}/")[-1]
+            return location.removeprefix(f"s3://{self.bucket_name}/")
         elif location.startswith("/"):
             # Path reconciliation for DRS objects that were created with block-storage.
             # Such DRS objects can be preserved when switching to S3 by uploading the objects to the same path:

--- a/chord_drs/backends/s3.py
+++ b/chord_drs/backends/s3.py
@@ -4,7 +4,6 @@ import botocore
 from bento_lib.streaming.exceptions import StreamingException
 from bento_lib.logging import log_level_from_str
 from boto3.s3.transfer import S3TransferConfig
-from flask import current_app
 from typing import AsyncIterator, Generator, TypedDict
 
 from chord_drs.constants import CHUNK_SIZE
@@ -36,7 +35,6 @@ class S3Backend(Backend):
         self.bucket_name = config["S3_BUCKET"]
 
         self.session = aioboto3.Session()
-        self.logger = current_app.logger
 
     async def _create_s3_client(self):
         return self.session.client(
@@ -62,7 +60,6 @@ class S3Backend(Backend):
         return f"s3://{self.bucket_name}/{object_key}"
 
     async def _retrieve_headers(self, object_key: str):
-        logging.debug(object_key)
         async with await self._create_s3_client() as s3:
             head = await s3.head_object(Bucket=self.bucket_name, Key=object_key)
         return {

--- a/chord_drs/backends/s3.py
+++ b/chord_drs/backends/s3.py
@@ -83,7 +83,7 @@ class S3Backend(Backend):
 
         async def stream_object():
             async with await self._create_s3_client() as s3_client:
-                response = await s3_client.get_object(Bucket=self.bucket_name, Key=location.split("/")[-1])
+                response = await s3_client.get_object(Bucket=self.bucket_name, Key=object_key)
                 body_stream = response["Body"]
                 while chunk := await body_stream.read(CHUNK_SIZE):
                     yield chunk

--- a/chord_drs/backends/s3.py
+++ b/chord_drs/backends/s3.py
@@ -61,6 +61,7 @@ class S3Backend(Backend):
         return f"s3://{self.bucket_name}/{object_key}"
 
     async def _retrieve_headers(self, object_key: str):
+        logging.debug(object_key)
         async with await self._create_s3_client() as s3:
             head = await s3.head_object(Bucket=self.bucket_name, Key=object_key)
         return {
@@ -72,6 +73,7 @@ class S3Backend(Backend):
 
     async def get_s3_object_dict(self, location: str) -> S3ObjectGenerator:
         # Where location is a full s3 path
+        logging.debug(location)
         object_key = location.split(f"s3://{self.bucket_name}/")[-1]
         headers = await self._retrieve_headers(object_key)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,21 +120,28 @@ def drs_base_url():
 
 
 @pytest.fixture
-def client_s3(s3_session, drs_base_url) -> Generator[FlaskClient, None, None]:
+def s3_config() -> dict:
+    return {
+        "S3_ENDPOINT": f"{S3_HOST}:{S3_PORT}",
+        "S3_ACCESS_KEY": "test_access_key",
+        "S3_SECRET_KEY": "test_secret_key",
+        "S3_BUCKET": "test",
+        "S3_REGION_NAME": "us-east-1",
+        "S3_VALIDATE_SSL": False,
+        "S3_USE_HTTPS": False,
+        "SERVICE_DATA_SOURCE": DATA_SOURCE_S3,
+        "AUTHZ_URL": AUTHZ_URL,
+    }
+
+
+@pytest.fixture
+def client_s3(s3_session, drs_base_url, s3_config) -> Generator[FlaskClient, None, None]:
     os.environ["BENTO_AUTHZ_SERVICE_URL"] = AUTHZ_URL
 
     import asyncio
     from chord_drs.app import db, application
 
-    application.config["S3_ENDPOINT"] = f"{S3_HOST}:{S3_PORT}"
-    application.config["S3_ACCESS_KEY"] = "test_access_key"
-    application.config["S3_SECRET_KEY"] = "test_secret_key"
-    application.config["S3_BUCKET"] = "test"
-    application.config["S3_REGION_NAME"] = "us-east-1"
-    application.config["S3_VALIDATE_SSL"] = False
-    application.config["S3_USE_HTTPS"] = False
-    application.config["SERVICE_DATA_SOURCE"] = DATA_SOURCE_S3
-    application.config["AUTHZ_URL"] = AUTHZ_URL
+    application.config.update(s3_config)
 
     with application.app_context():
         s3_backend = S3Backend(application.config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,7 +131,6 @@ def s3_config() -> dict:
         "S3_USE_HTTPS": False,
         "SERVICE_DATA_SOURCE": DATA_SOURCE_S3,
         "AUTHZ_URL": AUTHZ_URL,
-        "LOG_LEVEL": "info",
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,6 +131,7 @@ def s3_config() -> dict:
         "S3_USE_HTTPS": False,
         "SERVICE_DATA_SOURCE": DATA_SOURCE_S3,
         "AUTHZ_URL": AUTHZ_URL,
+        "LOG_LEVEL": "info",
     }
 
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -2,6 +2,7 @@ import pathlib
 import pytest
 
 from chord_drs.backends.local import LocalBackend
+from chord_drs.backends.s3 import S3Backend
 
 
 @pytest.mark.asyncio
@@ -24,3 +25,22 @@ async def test_local_backend_raises(local_volume):
     with pytest.raises(ValueError):
         # before we can even figure out file does not exist, this is not a local volume subpath:
         await backend.delete("/tmp/does_not_exist.txt")
+
+
+def test_s3_backend_location_handling(s3_config):
+    backend = S3Backend(s3_config)
+
+    # S3 location: DRS blobs created on an S3 backend
+    s3_location = f"s3://{backend.bucket_name}/some-blob"
+    s3_object_key = backend._location_to_object_key(s3_location)
+    assert s3_object_key == "some-blob"
+
+    # File system location: DRS blobs created on a local backend
+    s3_fs_location = "/drs/bento_drs/data/obj/some-blob"
+    s3_fs_object_key = backend._location_to_object_key(s3_fs_location)
+    assert s3_fs_object_key == s3_fs_location[1:]
+
+    # Invalid location: not an S3 path OR not an absolute fs path
+    invalid_location = "some-blob"
+    with pytest.raises(ValueError):
+        backend._location_to_object_key(invalid_location)


### PR DESCRIPTION
Adds a function to S3Backend to reconcile the location (path) of DRS blobs created on local storage.

Enables us to migrate the data from a local storage DRS to an S3 enabled DRS without changing the DB, see bento [docs](https://github.com/bento-platform/bento/blob/feat/drop-box-s3/docs/object_storage.md#drs) on migrating DRS to S3.